### PR TITLE
Fix bug where only the first requested token type was set

### DIFF
--- a/ceterach/api.py
+++ b/ceterach/api.py
@@ -227,7 +227,7 @@ class MediaWiki:
             for (k, v) in more_params.items():
                 final_dict[k] = v
         for (k, v) in final_dict.items():
-            if isinstance(v, (list, tuple)):
+            if isinstance(v, (list, tuple, set)):
                 final_dict[k] = "|".join(str(i) for i in v)
         final_dict.setdefault("action", "query")
         final_dict['format'] = 'json'


### PR DESCRIPTION
`ceterach.api.MediaWiki.set_token` can take in multiple token types to request, but actually requests only the first token type. This is because the list of token types is a `set`, but `MediaWiki._build_call_params` only correctly formats multiple parameters if it is in a `list` or `tuple`.