### PR TITLE
Move version declaration.

### DIFF
--- a/ceterach/__init__.py
+++ b/ceterach/__init__.py
@@ -18,6 +18,4 @@
 #-------------------------------------------------------------------------------
 
 from . import api, page, category, file, revision, user, exceptions
-
-__author__ = "Andrew Wang"
-__version__ = "0.0.1"
+from .version import __author__, __version__

--- a/ceterach/version.py
+++ b/ceterach/version.py
@@ -1,0 +1,2 @@
+__author__ = "Andrew Wang"
+__version__ = "0.0.1"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from ceterach import __version__
+from ceterach.version import __version__
 
 def read_long_description():
     try:


### PR DESCRIPTION
When `setup.py` imports `__version__` from `__init__.py`, other modules are imported. Since `setup.py` is used by pip as part of installation, if any dependencies are missing, installation fails. This means you can't simply do `pip install ...ceterach...`, you must first do `pip install arrow requests`. This is also problematic when using a `requirements.txt` type of file since you can't simply list the dependencies first, you must invoke pip twice.

Moved `__version__` to a dedicated file, and now `__init__.py` imports from it (as does `setup.py`).